### PR TITLE
Add functions to manage the comment of a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Uses the excellent [Go MySQL Driver][1].
 License
 -------
 
-Distributed under the MIT license. See `LICENSE.txt` for more information.
+Distributed under the MIT license. See `LICENSE.md` for more information.
 
 [1]: https://github.com/go-sql-driver/mysql

--- a/table.go
+++ b/table.go
@@ -5,6 +5,8 @@ package xmysql
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -30,4 +32,76 @@ func TableExists(db *sql.DB, name string) (bool, error) {
 		return false, NewError(err)
 	}
 	return true, nil
+}
+
+// TableComment retrieves the comment of a table. If schema is not provided, current schema
+// will be used.
+func TableComment(db *sql.DB, table string, schema ...string) (string, error) {
+	dml := `SELECT TABLE_COMMENT FROM information_schema.TABLES WHERE TABLE_NAME = ? AND TABLE_SCHEMA = SCHEMA()`
+	args := []any{table}
+	if len(schema) > 0 && schema[0] != "" {
+		dml = `SELECT TABLE_COMMENT FROM information_schema.TABLES WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?`
+		args = append(args, schema[0])
+	}
+
+	var comment string
+	if err := db.QueryRow(dml, args...).Scan(&comment); err != nil {
+		return "", err
+	}
+
+	return comment, nil
+}
+
+// TableCommentJSON retrieves the comment of a table, unmarshalls it as JSON, and stores it in
+// dest. If schema is not provided, current schema will be used.
+// Panics for same reasons as Go's json.Unmarshal would.
+func TableCommentJSON(db *sql.DB, table string, dest any, schema ...string) error {
+	dml := `SELECT TABLE_COMMENT FROM information_schema.TABLES WHERE TABLE_NAME = ? AND TABLE_SCHEMA = SCHEMA()`
+	args := []any{table}
+	if len(schema) > 0 && schema[0] != "" {
+		dml = `SELECT TABLE_COMMENT FROM information_schema.TABLES WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?`
+		args = append(args, schema[0])
+	}
+
+	var comment string
+	if err := db.QueryRow(dml, args...).Scan(&comment); err != nil {
+		return err
+	}
+
+	return json.Unmarshal([]byte(comment), dest)
+}
+
+// SetTableComment sets the table's comment. If schema is not provided, current schema
+// will be used.
+func SetTableComment(db *sql.DB, table string, comment string, schema ...string) error {
+	ddl := fmt.Sprintf("ALTER TABLE %s COMMENT = '%%s'", table)
+	if len(schema) > 0 && schema[0] != "" {
+		ddl = fmt.Sprintf("ALTER TABLE %s.%s COMMENT = '%%s'", schema[0], table)
+	}
+
+	if _, err := db.Exec(fmt.Sprintf(ddl, comment)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SetTableCommentJSON sets the table's comment marshalled as JSON. If schema is not provided, current schema
+// will be used.
+func SetTableCommentJSON(db *sql.DB, table string, comment any, schema ...string) error {
+	data, err := json.Marshal(comment)
+	if err != nil {
+		return err
+	}
+
+	ddl := fmt.Sprintf("ALTER TABLE %s COMMENT = '%%s'", table)
+	if len(schema) > 0 && schema[0] != "" {
+		ddl = fmt.Sprintf("ALTER TABLE %s.%s COMMENT = '%%s'", schema[0], table)
+	}
+
+	if _, err := db.Exec(fmt.Sprintf(ddl, string(data))); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/table_test.go
+++ b/table_test.go
@@ -4,7 +4,10 @@ package xmysql
 
 import (
 	"database/sql"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/golistic/xt"
 )
@@ -36,5 +39,121 @@ func TestTableExists(t *testing.T) {
 		have, err := TableExists(db, "mysqlmysqlmysql")
 		xt.KO(t, err)
 		xt.Assert(t, !have)
+	})
+}
+
+func TestTableComment(t *testing.T) {
+	schemaName := "xmysql_test_table_comments"
+	defer func() { _ = DropSchema(testDB, schemaName) }()
+
+	xt.OK(t, CreateSchema(testDB, schemaName))
+
+	dns, err := ReplaceDSNDatabase(testDSN, schemaName)
+	xt.OK(t, err)
+
+	db, err := sql.Open("mysql", dns)
+	xt.OK(t, err)
+	defer func() { _ = db.Close() }()
+
+	t.Run("comment from existing table", func(t *testing.T) {
+		exp := "I am comment"
+		ddl := "CREATE TABLE t1 (id INT) COMMENT='" + exp + "'"
+		_, err := db.Exec(ddl)
+		xt.OK(t, err)
+
+		have, err := TableComment(testDB, "t1", schemaName)
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("structured comment from table", func(t *testing.T) {
+		ddl := `CREATE TABLE t10 (id INT) COMMENT='{"comment":"I am a string in JSON","hits":32}'`
+		_, err := db.Exec(ddl)
+		xt.OK(t, err)
+
+		var have = struct {
+			Comment string `json:"comment"`
+			Hits    int    `json:"hits"`
+		}{}
+
+		xt.OK(t, TableCommentJSON(db, "t10", &have))
+		xt.OK(t, err)
+		xt.Eq(t, "I am a string in JSON", have.Comment)
+		xt.Eq(t, 32, have.Hits)
+	})
+
+	t.Run("incorrect data in structured comment from table", func(t *testing.T) {
+		ddl := `CREATE TABLE t11 (id INT) COMMENT='{"comment":"I am a string in JSON","hits":"oops"}'`
+		_, err := db.Exec(ddl)
+		xt.OK(t, err)
+
+		var have = struct {
+			Comment string `json:"comment"`
+			Hits    int    `json:"hits"`
+		}{}
+
+		err = TableCommentJSON(db, "t11", &have)
+		xt.KO(t, err)
+		xt.Eq(t, "json: cannot unmarshal string into Go struct field .hits of type int", err.Error())
+	})
+
+	t.Run("empty comment from existing table", func(t *testing.T) {
+		exp := ""
+		ddl := "CREATE TABLE t2 (id INT)"
+		_, err := db.Exec(ddl)
+		xt.OK(t, err)
+
+		have, err := TableComment(db, "t2")
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("comment from non-existing table", func(t *testing.T) {
+		_, err := TableComment(db, schemaName, "something_not_there")
+		xt.KO(t, err)
+		xt.Assert(t, errors.Is(err, sql.ErrNoRows))
+	})
+
+	t.Run("set string comment using current schema", func(t *testing.T) {
+		exp := "string comment"
+		ddl := "CREATE TABLE t3 (id INT)"
+		_, err := db.Exec(ddl)
+		xt.OK(t, err)
+
+		xt.OK(t, SetTableComment(db, "t3", exp))
+		have, err := TableComment(db, "t3")
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("set string comment providing schema", func(t *testing.T) {
+		exp := "string comment"
+		ddl := "CREATE TABLE t4 (id INT)"
+		_, err := db.Exec(ddl)
+		xt.OK(t, err)
+
+		xt.OK(t, SetTableComment(testDB, "t4", exp, schemaName))
+		have, err := TableComment(testDB, "t4", schemaName)
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("set comment as structured data (JSON)", func(t *testing.T) {
+		ts := time.Date(2023, 2, 10, 11, 27, 23, 0, time.UTC)
+		exp := fmt.Sprintf(`{"comment":"I am a string in JSON","added":"%s"}`, ts.Format(time.RFC3339))
+		ddl := "CREATE TABLE t5 (id INT)"
+		_, err := db.Exec(ddl)
+		xt.OK(t, err)
+
+		xt.OK(t, SetTableCommentJSON(db, "t5", struct {
+			Comment string    `json:"comment"`
+			Added   time.Time `json:"added"`
+		}{
+			Comment: "I am a string in JSON",
+			Added:   ts,
+		}))
+		have, err := TableComment(db, "t5")
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
 	})
 }


### PR DESCRIPTION
We add two new functions to retrieve the comment of a MySQL table:
* TableComment returns the comment as string
* TableCommentJSON unmarshalls JSON data (using json.Unmarshal)

Similar, two new functions to set the comment of a MySQL table:
* SetTableComment set table comment from string
* SetTableCommentJSON stores whatever is given as JSON