### PR TITLE
Add SQLw replacing placeholders in SQL statements

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,5 @@
+/*.imports.xml
+
 # Default ignored files
 /shelf/
 /workspace.xml

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/geertjanvdk/xkit v0.9.0-beta.6
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/golistic/xt v1.0.0
+	github.com/golistic/xt v1.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/golistic/xstrings v1.0.0 h1:blYH9nNTAc6f+tYQ8XVMQ6YtSwOKh5N1ldVnRI3CT
 github.com/golistic/xstrings v1.0.0/go.mod h1:0OequtLc+tesHgj1mgTpe+/nka4sVnfUO5IYmpxLPCc=
 github.com/golistic/xt v1.0.0 h1:s0CASEyLXylddqXLtZAALz1+ZL63USw5b4t49RegERo=
 github.com/golistic/xt v1.0.0/go.mod h1:j1ZuWefyOD4HegoapgSjbXanA7X9YOKUeEB5gsEPgYg=
+github.com/golistic/xt v1.0.1 h1:prcwpL757GEu+dj6x2v6vxHkulkFdyQ3S1PqO+6ohPM=
+github.com/golistic/xt v1.0.1/go.mod h1:j1ZuWefyOD4HegoapgSjbXanA7X9YOKUeEB5gsEPgYg=
 golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=

--- a/sql.go
+++ b/sql.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmysql
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SQLw takes the SQL statement and substitutes the key/value pairs using
+// the placeholder format `$(key)`.
+// For example, executing `SQLw("SELECT c1 FROM $(tblName)", tblName, "t1")` results
+// in `SELECT c1 FROM $(tblName)`.
+// If a key is found within a quoted part of the statement, it is not substituted.
+// Dangling keys (key without value) are ignored.
+//
+// Important! You must use as much as possible parameter placeholders such as '?' or
+// '$1'. This is however not always possible: for example, when using a dynamic schema
+// or table based on context.
+func SQLw(statement string, keyValuePairs ...string) (string, error) {
+	queryLen := len(statement)
+
+	values := map[string]string{}
+
+	for i := 0; i < len(keyValuePairs); {
+		if i+1 == len(keyValuePairs) {
+			// dangling; ignore
+			break
+		}
+		key, val := keyValuePairs[i], keyValuePairs[i+1]
+		values[key] = val
+		i += 2
+	}
+
+	var result strings.Builder
+	qb := []byte(statement)
+	var quoted byte
+	substituted := map[string]struct{}{}
+	notProvided := map[string]struct{}{}
+
+	for p := 0; p < queryLen; p++ {
+		if qb[p] == quoted {
+			// end of quoted part
+			quoted = 0
+		} else if qb[p] == '\'' || qb[p] == '"' || qb[p] == '`' {
+			// start of quoted part
+			quoted = qb[p]
+		} else if quoted == 0 && qb[p] == '$' && (p+1 < queryLen && qb[p+1] == '(') {
+			// handle substitution
+			pos := p
+			p += 2
+			var key strings.Builder
+			for ; statement[p] != ')'; p++ {
+				if p+1 >= queryLen {
+					return "", fmt.Errorf("xmysql: unclosed substitution at position %d", pos)
+				}
+				key.WriteByte(statement[p])
+			}
+			if v, ok := values[key.String()]; ok {
+				result.WriteString(v)
+				substituted[key.String()] = struct{}{}
+			} else {
+				notProvided[key.String()] = struct{}{}
+			}
+			continue
+		}
+
+		result.WriteByte(qb[p])
+	}
+
+	switch {
+	case len(values) != len(substituted):
+		var missing []string
+		for k := range values {
+			if _, ok := substituted[k]; !ok {
+				missing = append(missing, k)
+			}
+		}
+		sort.Strings(missing)
+		return "", fmt.Errorf("xmysql: placeholder missing for %s", strings.Join(missing, ","))
+	case len(notProvided) > 0:
+		var missing []string
+		for k := range notProvided {
+			missing = append(missing, k)
+		}
+		sort.Strings(missing)
+		return "", fmt.Errorf("xmysql: key/value missing for %s", strings.Join(missing, ","))
+	}
+
+	return result.String(), nil
+}
+
+// MustSQLw calls SQLw but instead of returning errors, it panics.
+func MustSQLw(statement string, keyValuePairs ...string) string {
+	s, err := SQLw(statement, keyValuePairs...)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmysql
+
+import (
+	"testing"
+
+	"github.com/golistic/xt"
+)
+
+func TestSQLw(t *testing.T) {
+	t.Run("common cases", func(t *testing.T) {
+		var cases = []struct {
+			stmt      string
+			keyValues []string
+			exp       string
+		}{
+			{
+				exp:       "SELECT 1 FROM t1",
+				stmt:      "SELECT 1 FROM $(tblName)",
+				keyValues: []string{"tblName", "t1"},
+			},
+			{
+				exp:       "SELECT 1 AS t1_value FROM t1",
+				stmt:      "SELECT 1 AS $(tblName)_value FROM $(tblName)",
+				keyValues: []string{"tblName", "t1"},
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.stmt, func(t *testing.T) {
+				xt.Eq(t, c.exp, MustSQLw(c.stmt, c.keyValues...))
+			})
+		}
+	})
+
+	t.Run("placeholders within quotes", func(t *testing.T) {
+		var cases = map[string]struct {
+			stmt      string
+			keyValues []string
+			exp       string
+		}{
+			"single quotes": {
+				exp:       "SELECT 1 FROM t1 WHERE c1 = '$(value)'",
+				stmt:      "SELECT 1 FROM $(tblName) WHERE c1 = '$(value)'",
+				keyValues: []string{"tblName", "t1"},
+			},
+			"double quotes": {
+				exp:       `SELECT 1 FROM t1 WHERE c1 = "$(value)"`,
+				stmt:      `SELECT 1 FROM $(tblName) WHERE c1 = "$(value)"`,
+				keyValues: []string{"tblName", "t1"},
+			},
+			"backticks": {
+				exp:       "SELECT 1 FROM t1 WHERE c1 = `$(value)` OR c2 = 5",
+				stmt:      "SELECT 1 FROM $(tblName) WHERE c1 = `$(value)` OR c2 = $(value)",
+				keyValues: []string{"tblName", "t1", "value", "5"},
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.stmt, func(t *testing.T) {
+				xt.Eq(t, c.exp, MustSQLw(c.stmt, c.keyValues...))
+			})
+		}
+	})
+
+	t.Run("key without value is ignored (dangling)", func(t *testing.T) {
+		exp := "SELECT 1 FROM t1"
+		stmt := "SELECT 1 FROM $(tblName)"
+		keyValues := []string{"tblName", "t1", "lonelyKey"}
+
+		xt.Eq(t, exp, MustSQLw(stmt, keyValues...))
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		_, err := SQLw("SELECT 1 FROM $(tblName) JOIN $(otherTableName)")
+		xt.KO(t, err)
+		xt.Eq(t, "xmysql: key/value missing for otherTableName,tblName", err.Error())
+	})
+
+	t.Run("missing placeholders", func(t *testing.T) {
+		_, err := SQLw("SELECT 1 FROM $(tblName)", "tblName", "t1", "column", "c1")
+		xt.KO(t, err)
+		xt.Eq(t, "xmysql: placeholder missing for column", err.Error())
+	})
+}


### PR DESCRIPTION
We add the function `SQLw()` which takes a statement and key/value pairs as variadic arguments. Placeholders are of the format `$(key)`. For example, a typical use-case is to substitute the table name dynamically in queries:

    SQLw("SELECT c1 FROM $(tblName)", "tblName", "t1")

Placeholders within single or double quotes, or backticks, are ignored.

The companion function `MustSQLw` is also available: it panics instead of reading an error.